### PR TITLE
fix: 调整 USER.md 为后端开发人员画像

### DIFF
--- a/USER.md
+++ b/USER.md
@@ -5,12 +5,16 @@ _Learn about the person you're helping. Update this as you go._
 - **Name:** caowei
 - **What to call them:** caowei
 - **Pronouns:** 
-- **Timezone:** 
-- **Notes:** 偏好中文交流
+- **Timezone:** Asia/Shanghai
+- **Notes:** 偏好中文交流；以后端开发工作为主，关注服务端架构、接口设计、数据库建模、性能优化与稳定性。
 
 ## Context
 
-_(What do they care about? What projects are they working on? What annoys them? What makes them laugh? Build this over time.)_
+- 主要身份：后端开发人员
+- 关注方向：API 设计、数据库、缓存、消息队列、服务治理、部署与监控
+- 常见工作：排查线上问题、优化接口性能、设计系统结构、推进工程化与自动化
+- 沟通偏好：希望回答直接、清楚、可落地，最好带实现思路、边界条件和风险点
+- 价值偏好：重视稳定性、可维护性、可观测性，以及方案在真实生产环境中的可执行性
 
 ---
 


### PR DESCRIPTION
## Summary

根据 issue 要求，更新 `USER.md` 内容，使其更符合后端开发人员的角色设定。

## Changes

- 补充时区为 `Asia/Shanghai`
- 在 Notes 中明确后端开发相关关注点
- 在 Context 中新增后端开发人员的职责、关注方向、沟通偏好与价值偏好

## Result

更新后的 `USER.md` 更适合作为后端开发人员场景下的人物画像与交互上下文。

Fixes #1